### PR TITLE
use mongodb URI instead of host & port to allow for auth

### DIFF
--- a/record/config.py.example
+++ b/record/config.py.example
@@ -11,16 +11,14 @@ DB_CONFIG = {
     # specified).
     "target_collections": [],
     "oplog_server": {
-        "host": "localhost",
-        "port": 27017,
+        "mongodb_uri": "mongodb://localhost:27017"
     },
     # In most cases you will record from the profile DB on the primary
     # If you are also sending queries to secondaries, you may want to specify
     # a list of secondary servers in addition to the primary
     "profiler_servers": [
         {
-            "host": "localhost",
-            "port": 27017,
+            "mongodb_uri": "mongodb://localhost:27017"
         }
     ],
     "oplog_output_file": "./OPLOG_OUTPUT",

--- a/record/pull_oplog.py
+++ b/record/pull_oplog.py
@@ -74,8 +74,8 @@ def main():
     output = open(sys.argv[2], "w")
 
     # Get the tailer for oplog
-    oplog_server = db_config["oplog_server"]
-    oplog_client = MongoClient(oplog_server["host"], oplog_server["port"])
+    mongodb_uri = db_config["oplog_server"]["mongodb_uri"]
+    oplog_client = MongoClient(mongodb_uri)
     tailer = utils.get_oplog_tailer(oplog_client,
                                     ["i", "u"],
                                     db_config["target_database"],


### PR DESCRIPTION
Currently the Record tool cannot pull operation data from a mongod instance using authentication. Using the MongoDB URI to connect will allow for this.
