### PR TITLE
pcap_converter to output proper bson and added 'insert' operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ pcap_converter is an experimental way to build a recorded ops file from a pcap o
 
 ```sh
 $ go get github.com/ParsePlatform/flashback/cmd/pcap_converter
-$ tcpdump -i lo0 -w some_mongo_cap.pcap 'dst port 27017'
-$ pcap_converter -f some_mongo_cap.pcap > ops_filename.json
+$ tcpdump -i lo0 -w some_mongo_cap.pcap 'tcp and dst port 27017'
+$ pcap_converter -f some_mongo_cap.pcap -o ops_filename.bson
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ For a full list of options:
 
 pcap_converter is an experimental way to build a recorded ops file from a pcap of mongo traffic.
 
+*Note: 'update', 'remove' and 'getmore' operations are not yet supported by pcap_converter*
+
 ```sh
 $ go get github.com/ParsePlatform/flashback/cmd/pcap_converter
 $ tcpdump -i lo0 -w some_mongo_cap.pcap 'tcp and dst port 27017'

--- a/cmd/pcap_converter/main.go
+++ b/cmd/pcap_converter/main.go
@@ -135,8 +135,11 @@ func (fbOp *Operation) handleDelete(opDelete *mongoproto.OpDelete, f *os.File) e
 
 func (op *Operation) writeOp(f *os.File) error {
 	opBson, err := bson.Marshal(op)
+	if err != nil {
+		return err
+	}
 	f.Write(opBson)
-	return err
+	return nil
 }
 
 func main() {

--- a/cmd/pcap_converter/main.go
+++ b/cmd/pcap_converter/main.go
@@ -74,8 +74,7 @@ func (fbOp *Operation) handleQuery(opQuery *mongoproto.OpQuery, f *os.File) erro
 	return fbOp.writeOp(f)
 }
 
-func (fbOp *Operation) handleInsertDocument(ns string, document bson.D, f *os.File) error {
-	fbOp.Ns = ns
+func (fbOp *Operation) handleInsertDocument(document bson.D, f *os.File) error {
 	fbOp.Type = flashback.Insert
 	fbOp.InsertDoc = document
 	return fbOp.writeOp(f)
@@ -89,7 +88,7 @@ func (fbOp *Operation) handleInsert(opInsert *mongoproto.OpInsert, f *os.File) e
 			if err != nil {
 				return err
 			}
-			err = fbOp.handleInsertDocument(fbOp.Ns, insert, f)
+			err = fbOp.handleInsertDocument(insert, f)
 			if err != nil {
 				return err
 			}
@@ -108,13 +107,13 @@ func (fbOp *Operation) handleInsertFromQuery(opQuery *mongoproto.OpQuery, f *os.
 	if exists == true {
 		if (reflect.TypeOf(documents).Kind() == reflect.Slice) {
 			for _, document := range documents.([]interface{}) {
-				err = fbOp.handleInsertDocument(fbOp.Ns, document.(bson.D), f)
+				err = fbOp.handleInsertDocument(document.(bson.D), f)
 				if err != nil {
 					return err
 				}
 			}
 		} else {
-			err = fbOp.handleInsertDocument(fbOp.Ns, documents.(bson.D), f)
+			err = fbOp.handleInsertDocument(documents.(bson.D), f)
 			if err != nil {
 				return err
 			}

--- a/cmd/pcap_converter/main.go
+++ b/cmd/pcap_converter/main.go
@@ -2,7 +2,7 @@
 package main
 
 import (
-	//"fmt"
+	"fmt"
 	"flag"
 	"time"
 	"log"
@@ -149,7 +149,7 @@ func main() {
 
 	pcap, err := pcap.OpenOffline(*pcapFile)
 	if err != nil {
-		logger.Println(os.Stderr, "error opening pcap file:", err)
+		fmt.Println(os.Stderr, "error opening pcap file:", err)
 		os.Exit(1)
 	}
 	h := mongocaputils.NewPacketHandler(pcap)
@@ -170,17 +170,18 @@ func main() {
 			fbOp := &Operation{
 				Timestamp: op.Seen,
 			}
-			if *debug == true {
-				if _, ok := op.Op.(*mongoproto.OpUnknown); ok {
-					logger.Println("Found unknown operation")
-				}
-			}
 			if opDelete, ok := op.Op.(*mongoproto.OpDelete); ok {
 				err = fbOp.handleDelete(opDelete, f)
 			} else if opInsert, ok := op.Op.(*mongoproto.OpInsert); ok {
 				err = fbOp.handleInsert(opInsert, f)
 			} else if opQuery, ok := op.Op.(*mongoproto.OpQuery); ok {
 				err = fbOp.handleQuery(opQuery, f)
+			} else if *debug == true {
+				if _, ok := op.Op.(*mongoproto.OpUnknown); ok {
+					fmt.Println("Found mongoproto.OpUnknown operation: ", op)
+				} else {
+					fmt.Println("No known type for operation: ", op)
+				}
 			}
 			if err != nil {
 				logger.Println(err)
@@ -192,7 +193,7 @@ func main() {
 	}()
 
 	if err := h.Handle(m, -1); err != nil {
-		logger.Println(os.Stderr, "pcap_converter: error handling packet stream:", err)
+		fmt.Println(os.Stderr, "pcap_converter: error handling packet stream:", err)
 	}
 	<-ch
 }

--- a/cmd/pcap_converter/main.go
+++ b/cmd/pcap_converter/main.go
@@ -9,11 +9,11 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/ParsePlatform/flashback"
 	"github.com/google/gopacket/pcap"
 	"github.com/tmc/mongocaputils"
 	"github.com/tmc/mongoproto"
 	"gopkg.in/mgo.v2/bson"
-	"github.com/ParsePlatform/flashback"
 )
 
 var (
@@ -62,10 +62,10 @@ func main() {
 					}
 				}
 				if strings.HasSuffix(opQuery.FullCollectionName, ".$cmd") {
-					fbOp.Type = "command"
+					fbOp.Type = flashback.Command
 					fbOp.CommandDoc = query
 				} else {
-					fbOp.Type = "query"
+					fbOp.Type = flashback.Query
 					fbOp.QueryDoc = query
 				}
 				fbOpStr, err := bson.Marshal(fbOp)

--- a/cmd/pcap_converter/main.go
+++ b/cmd/pcap_converter/main.go
@@ -74,15 +74,15 @@ func (fbOp *Operation) handleInsert(query bson.D, f *os.File) error {
 			fbOp.InsertDoc = documents.(bson.D)
 			inserts = append(inserts, fbOp)
 		}
-		for _, insert := range inserts {
-			err = insert.writeOp(f)
-			if err != nil {
-				return err
-			}
-		}
 	} else {
 		fbOp.InsertDoc = query
-		err = fbOp.writeOp(f)
+		inserts = append(inserts, fbOp)
+	}
+	for _, insert := range inserts {
+		err = insert.writeOp(f)
+		if err != nil {
+			return err
+		}
 	}
 	return err 
 }

--- a/cmd/pcap_converter/main.go
+++ b/cmd/pcap_converter/main.go
@@ -149,7 +149,7 @@ func main() {
 
 	pcap, err := pcap.OpenOffline(*pcapFile)
 	if err != nil {
-		fmt.Println(os.Stderr, "error opening pcap file:", err)
+		fmt.Fprintln(os.Stderr, "error opening pcap file:", err)
 		os.Exit(1)
 	}
 	h := mongocaputils.NewPacketHandler(pcap)
@@ -193,7 +193,7 @@ func main() {
 	}()
 
 	if err := h.Handle(m, -1); err != nil {
-		fmt.Println(os.Stderr, "pcap_converter: error handling packet stream:", err)
+		fmt.Fprintln(os.Stderr, "pcap_converter: error handling packet stream:", err)
 	}
 	<-ch
 }

--- a/cmd/pcap_converter/main.go
+++ b/cmd/pcap_converter/main.go
@@ -2,14 +2,14 @@
 package main
 
 import (
-	"fmt"
 	"flag"
-	"time"
+	"fmt"
 	"log"
 	"os"
+	"reflect"
 	"runtime"
 	"strings"
-	"reflect"
+	"time"
 
 	"github.com/ParsePlatform/flashback"
 	"github.com/google/gopacket/pcap"

--- a/cmd/pcap_converter/main.go
+++ b/cmd/pcap_converter/main.go
@@ -58,7 +58,7 @@ func (fbOp *Operation) handleQuery(opQuery *mongoproto.OpQuery, f *os.File) erro
 	var err error
 	fbOp.Ns = opQuery.FullCollectionName
 	fbOp.Type = flashback.Query
-	fbOp.QueryDoc, err = parseQuery(opQuery.Query)
+	query, err := parseQuery(opQuery.Query)
 	if err != nil {
 		return err
 	}
@@ -72,12 +72,8 @@ func (fbOp *Operation) handleQuery(opQuery *mongoproto.OpQuery, f *os.File) erro
 			return fbOp.handleCommand(opQuery, f)
 		}
 	} else {
-		//_, exists := flashback.GetElem(fbOp.QueryDoc, "insert")
-		//if exists == true {
-		//	return fbOp.handleInsertFromQuery(opQuery, f)
-		//} else {
+		fbOp.QueryDoc = query
 		return fbOp.writeOp(f)
-		//}
 	}
 }
 

--- a/op.go
+++ b/op.go
@@ -41,14 +41,14 @@ type Op struct {
 	Ns         string    `bson:"ns"`
 	Timestamp  time.Time `bson:"ts"`
 	Type       OpType    `bson:"op"`
-	NToSkip    int64     `bson:"ntoskip"`
-	NToReturn  int64     `bson:"ntoreturn"`
-	QueryDoc   bson.D    `bson:"query"`
-	CommandDoc bson.D    `bson:"command"`
-	InsertDoc  bson.D    `bson:"o"`
-	UpdateDoc  bson.D    `bson:"updateobj"`
-	Database   string
-	Collection string
+	NToSkip    int64     `bson:"ntoskip,omitempty"`
+	NToReturn  int64     `bson:"ntoreturn,omitempty"`
+	QueryDoc   bson.D    `bson:"query,omitempty"`
+	CommandDoc bson.D    `bson:"command,omitempty"`
+	InsertDoc  bson.D    `bson:"o,omitempty"`
+	UpdateDoc  bson.D    `bson:"updateobj,omitempty"`
+	Database   string    `bson:",omitempty"`
+	Collection string    `bson:",omitempty"`
 }
 
 // GetElem is a helper to fetch a specific key from bson.D


### PR DESCRIPTION
As @tredman and I discussed in #38, this PR fixes the issue with pcap_converter outputting the older JSON-based format that the current go-based 'flashback' command did not recognise.

I also planned on adding any missing operations to the parser (it only parsed queries and commands), but I hit a wall with tmc/mongoproto missing functions for opDelete and opUpdate, so I'll come back with a 2nd PR to add deletes and updates. I was able to add 'insert' operations, however.

Summary of changes:
- Parsing output file to bson (instead of JSON).
- Working operations: query, command (count and findandmodify) and inserts (new).
- Output file written from inside program instead of to STDOUT (which was corrupting the BSON). Maybe this can support STDOUT later.
- Go structs to maintain bson ordering.
- "-debug" flag added.
- Updated README.md to mention what's unsupported.
- Updated README.md 'tcpdump' command to be TCP-only.

Lastly, I'm a golang noob who would love any pointers on my code. Fire away any suggestions!
