### PR TITLE
Adding mongoproto.OpDelete and mongoproto.OpUpdate to cmd/pcap_converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ For a full list of options:
 
 pcap_converter is an experimental way to build a recorded ops file from a pcap of mongo traffic.
 
-*Note: 'update', 'remove' and 'getmore' operations are not yet supported by pcap_converter*
+*Note: 'getmore' operations are not yet supported by pcap_converter*
 
 ```sh
 $ go get github.com/ParsePlatform/flashback/cmd/pcap_converter


### PR DESCRIPTION
Adding mongoproto.OpDelete and mongoproto.OpUpdate to 'pcap_converter' now that they're supported in tmc/mongoproto after this PR was merged: https://github.com/tmc/mongoproto/pull/2.

This resolves 2 of 3 missing ops in #40, so I will close #40 if this is merged and open a getmore-specific issue for the final missing op.

Example update op:
```
$ bsondump flashback.bson 2>/dev/null | grep \"op\":\"update\" | head -1
{"ns":"test.lag_check","ts":{"$date":"2016-10-14T19:02:19.400Z"},"op":"update","query":{"_id":1},"updateobj":{"_id":1,"x":1}}
```

Example delete (remove) op:
```
$ bsondump flashback.bson 2>/dev/null | grep \"op\":\"remove\" | head -1
{"ns":"test.items","ts":{"$date":"2016-10-14T19:03:38.380Z"},"op":"remove","query":{"_id":{"$oid":"58012bb839f7e32dab46b8ae"}}}
```

Any thoughts/suggestions appreciated!